### PR TITLE
Clarify documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # pydbg 🐛 [![Build Status](https://travis-ci.org/tylerwince/pydbg.svg?branch=master)](https://travis-ci.org/tylerwince/pydbg)
 
-`pydbg` is an implementation of the Rust2018 builtin debugging macro `dbg`.
+`pydbg` is an implementation of the [Rust builtin debugging macro `dbg`](https://rust-lang.github.io/rfcs/2361-dbg-macro.html)
 
 The purpose of this package is to provide a better and more effective workflow for
 people who are "print debuggers".
 
 `pip install pydbg`
-
-`from pydbg import dbg`
 
 ## The old way:
 
@@ -34,6 +32,7 @@ a squared with my function = 4
 ## The _new_ (and better) way
 
 ```python
+from pydbg import dbg
 
 a = 2
 b = 3

--- a/pydbg.py
+++ b/pydbg.py
@@ -1,4 +1,4 @@
-"""pydbg is an implementation of the Rust2018 builtin `dbg` for Python."""
+"""pydbg is an implementation of the Rust builtin `dbg!` for Python."""
 
 import inspect
 import sys
@@ -14,8 +14,8 @@ _ExpType = typing.TypeVar('_ExpType')
 def dbg(exp: _ExpType) -> _ExpType:
     """Call dbg with any variable or expression.
 
-    Calling debug will print out the content information (file, lineno) as wil as the
-    passed expression and what the expression is equal to::
+    Calling dbg will print to stderr the current filename and lineno,
+    as well as the passed expression and what the expression evaluates to:
 
         from pydbg import dbg
 


### PR DESCRIPTION
Link to info on dbg!

Note that dbg! is not actually part of Rust 2018, but rather Rust-next, as you can see at
https://doc.rust-lang.org/edition-guide/rust-next/dbg-macro.html

Separate install from usage: move import, make example just work

Note that in Python you do have to import it, while in Rust
it is part of the standard prelude.